### PR TITLE
Remove enforced sorting option when building a batcher.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,5 @@
+## 0.1.1 (2016-02-26)
+
+Bugfixes:
+
+  - Remove enforced ordering when a Mongoid criteria with an existing sort is supplied

--- a/README.md
+++ b/README.md
@@ -2,8 +2,7 @@
 
 A Ruby library to run Mongoid queries on large collections in batches.
 
-**Supported Ruby versions:** 2.1, 2.2
-
+**Supported Ruby versions:** 2.1, 2.2  
 **Supported Mongoid versions:** 4.0, 5.0
 
 ## Installation

--- a/config/mongoid.yml
+++ b/config/mongoid.yml
@@ -1,5 +1,5 @@
 test:
-  sessions:
+  clients:
     default:
       database: test
       hosts:

--- a/lib/mongo_batch.rb
+++ b/lib/mongo_batch.rb
@@ -15,15 +15,23 @@ module MongoBatch
         processed_so_far = offset
 
         offset.step(by: batch_size, to: to - batch_size).each do |offset|
-          yielder << query.order_by(order_by).limit(batch_size).skip(offset)
+          yielder << with_order.limit(batch_size).skip(offset)
           processed_so_far += batch_size
         end
 
         if processed_so_far < to
           last_limit = to - processed_so_far
-          yielder << query.order(order_by).limit(last_limit).skip(processed_so_far)
+          yielder << with_order.limit(last_limit).skip(processed_so_far)
         end
       end
+    end
+
+    def with_order
+      options.sort ? query : query.order_by(order_by)
+    end
+
+    def options
+      query.criteria.options
     end
   end
 

--- a/mongo_batch.gemspec
+++ b/mongo_batch.gemspec
@@ -1,7 +1,7 @@
 Gem::Specification.new do |spec|
   spec.name          = 'mongo_batch'
-  spec.version       = '0.1.0'
-  spec.authors       = ['Oliver Martell']
+  spec.version       = '0.1.1'
+  spec.authors       = ['Oliver Martell', 'Matthew MacLeod']
   spec.email         = ['support@altmetric.com']
   spec.summary       = 'A library to batch Mongo queries'
   spec.description   = <<-EOF
@@ -17,7 +17,7 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency 'bundler', '~> 1.10'
   spec.add_development_dependency 'rake', '~> 10.0'
   spec.add_development_dependency 'rspec', '~> 3.3'
-  spec.add_development_dependency 'mongoid', '~> 4.0'
+  spec.add_development_dependency 'mongoid', '~> 5.0'
   spec.add_development_dependency 'database_cleaner', '~> 1.5'
   spec.add_development_dependency 'factory_girl', '~> 4.5'
 end

--- a/spec/mongo_batch_spec.rb
+++ b/spec/mongo_batch_spec.rb
@@ -8,6 +8,7 @@ describe MongoBatch do
     extend MongoBatch
 
     field :body, type: String
+    field :index, type: Integer
   end
 
   describe '#find_in_batches' do
@@ -83,6 +84,16 @@ describe MongoBatch do
             .map(&:id)
 
       expect(ids).to eq(posts.map(&:id).reverse)
+    end
+
+    it 'does not enforce an order if one is already applied' do
+      posts = 1.upto(10).map { |n| FactoryGirl.create(:post, index: n) }
+
+      posts_in_batches = described_class
+                         .in_batches(Post.desc(:index), batch_size: 5)
+                         .map(&:to_a)
+
+      expect(posts_in_batches).to eq([posts[5..9].reverse, posts[0..4].reverse])
     end
 
     it 'preserves any scopes previously applied' do


### PR DESCRIPTION
This allows us to pass a Mongo criteria that already includes a sort
order, without having it overriden by the enforced sort on `_id`.
